### PR TITLE
Enhance maskInputValue

### DIFF
--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrdom",
-  "version": "2.0.0-alpha.7.2",
+  "version": "2.0.0-alpha.7.15",
   "homepage": "https://github.com/rrweb-io/rrweb/tree/main/packages/rrdom#readme",
   "license": "MIT",
   "main": "lib/rrdom.cjs",
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",
-    "@rrweb/types": "npm:@fullview/rrweb-types@2.0.0-alpha.7.2",
+    "@rrweb/types": "npm:@fullview/rrweb-types@2.0.0-alpha.7.15",
     "@types/jest": "^27.4.1",
     "@types/puppeteer": "^5.4.4",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
@@ -47,6 +47,6 @@
     "ts-jest": "^27.1.3"
   },
   "dependencies": {
-    "rrweb-snapshot": "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.2"
+    "rrweb-snapshot": "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.15"
   }
 }

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb-snapshot",
-  "version": "2.0.0-alpha.7.2",
+  "version": "2.0.0-alpha.7.15",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -501,6 +501,7 @@ function serializeNode(
         blockSelector,
         deleteSelector,
         inlineStylesheet,
+        maskTextSelector,
         maskInputOptions,
         maskInputFn,
         dataURLOptions,
@@ -607,6 +608,7 @@ function serializeElementNode(
     blockSelector: string | null;
     deleteSelector: string | null;
     inlineStylesheet: boolean;
+    maskTextSelector: string | null;
     maskInputOptions: MaskInputOptions;
     maskInputFn: MaskInputFn | undefined;
     dataURLOptions?: DataURLOptions;
@@ -626,6 +628,7 @@ function serializeElementNode(
     blockSelector,
     deleteSelector,
     inlineStylesheet,
+    maskTextSelector,
     maskInputOptions = {},
     maskInputFn,
     dataURLOptions = {},
@@ -696,11 +699,17 @@ function serializeElementNode(
         : typeof attributes.type === 'string'
         ? attributes.type.toLowerCase()
         : null;
+
+      const matchesTextSelector = maskTextSelector
+        ? n.matches(maskTextSelector)
+        : false;
+
       attributes.value = maskInputValue({
         type,
         tagName,
         value,
         maskInputOptions,
+        matchesTextSelector,
         maskInputFn,
       });
     } else if (checked) {

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -158,12 +158,14 @@ export function maskInputValue({
   tagName,
   type,
   value,
+  matchesTextSelector,
   maskInputFn,
 }: {
   maskInputOptions: MaskInputOptions;
   tagName: string;
   type: string | null;
   value: string | null;
+  matchesTextSelector: boolean;
   maskInputFn?: MaskInputFn;
 }): string {
   let text = value || '';
@@ -171,7 +173,8 @@ export function maskInputValue({
 
   if (
     maskInputOptions[tagName.toLowerCase() as keyof MaskInputOptions] ||
-    (actualType && maskInputOptions[actualType as keyof MaskInputOptions])
+    (actualType && maskInputOptions[actualType as keyof MaskInputOptions]) ||
+    matchesTextSelector
   ) {
     if (maskInputFn) {
       text = maskInputFn(text);

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb",
-  "version": "2.0.0-alpha.7.5",
+  "version": "2.0.0-alpha.7.15",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",
@@ -77,13 +77,13 @@
     "tslib": "^2.3.1"
   },
   "dependencies": {
-    "@rrweb/types": "npm:@fullview/rrweb-types@2.0.0-alpha.7.2",
+    "@rrweb/types": "npm:@fullview/rrweb-types@2.0.0-alpha.7.15",
     "@types/css-font-loading-module": "0.0.7",
     "@xstate/fsm": "^1.4.0",
     "base64-arraybuffer": "^1.0.1",
     "fflate": "^0.4.4",
     "mitt": "^3.0.0",
-    "rrdom": "npm:@fullview/rrdom@2.0.0-alpha.7.2",
-    "rrweb-snapshot": "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.2"
+    "rrdom": "npm:@fullview/rrdom@2.0.0-alpha.7.15",
+    "rrweb-snapshot": "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.15"
   }
 }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -496,11 +496,16 @@ export default class MutationBuffer {
         if (attributeName === 'value') {
           const type = getInputType(target);
 
+          const matchesTextSelector = this.maskTextSelector
+            ? target.matches(this.maskTextSelector)
+            : false;
+
           value = maskInputValue({
             maskInputOptions: this.maskInputOptions,
             tagName: target.tagName,
             type,
             value,
+            matchesTextSelector,
             maskInputFn: this.maskInputFn,
           });
         }

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -351,6 +351,7 @@ function initInputObserver({
   blockClass,
   blockSelector,
   ignoreClass,
+  maskTextSelector,
   maskInputOptions,
   maskInputFn,
   sampling,
@@ -384,17 +385,23 @@ function initInputObserver({
     let isChecked = false;
     const type: Lowercase<string> = getInputType(target) || '';
 
+    const matchesTextSelector = maskTextSelector
+      ? target.matches(maskTextSelector)
+      : false;
+
     if (type === 'radio' || type === 'checkbox') {
       isChecked = (target as HTMLInputElement).checked;
     } else if (
       maskInputOptions[tagName.toLowerCase() as keyof MaskInputOptions] ||
-      maskInputOptions[type as keyof MaskInputOptions]
+      maskInputOptions[type as keyof MaskInputOptions] ||
+      matchesTextSelector
     ) {
       text = maskInputValue({
         maskInputOptions,
         tagName,
         type,
         value: text,
+        matchesTextSelector,
         maskInputFn,
       });
     }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb-types",
-  "version": "2.0.0-alpha.7.2",
+  "version": "2.0.0-alpha.7.15",
   "publishConfig": {
     "access": "public"
   },
@@ -43,7 +43,7 @@
     "vite-plugin-dts": "^1.6.6"
   },
   "dependencies": {
-    "rrweb-snapshot": "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.2"
+    "rrweb-snapshot": "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.15"
   },
   "browserslist": [
     "supports es6-class"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2622,12 +2622,12 @@
   dependencies:
     rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7"
 
-"@rrweb/types@npm:@fullview/rrweb-types@2.0.0-alpha.7.11":
-  version "2.0.0-alpha.7.11"
-  resolved "https://registry.yarnpkg.com/@fullview/rrweb-types/-/rrweb-types-2.0.0-alpha.7.11.tgz#eb920713d2370680bd50bf02590528f675a317e7"
+"@rrweb/types@npm:@fullview/rrweb-types@2.0.0-alpha.7.15":
+  version "2.0.0-alpha.7.15"
+  resolved "https://registry.yarnpkg.com/@fullview/rrweb-types/-/rrweb-types-2.0.0-alpha.7.15.tgz#eb920713d2370680bd50bf02590528f675a317e7"
   integrity sha512-8/4hNVOkppsEgd43Mtg+MbbsAIHXzV39nxMUCKmBw0aJyP2eYM4HQqz5Cq0/d8RVOrdMKW7/48ztTB3Lbdpbxg==
   dependencies:
-    rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.11"
+    rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.15"
 
 "@rushstack/node-core-library@3.53.2", "@rushstack/node-core-library@^3.53.2":
   version "3.53.2"
@@ -11826,12 +11826,12 @@ rrdom@^2.0.0-alpha.7:
   dependencies:
     rrweb-snapshot "^2.0.0-alpha.7"
 
-"rrdom@npm:@fullview/rrdom@2.0.0-alpha.7.11":
-  version "2.0.0-alpha.7.11"
-  resolved "https://registry.yarnpkg.com/@fullview/rrdom/-/rrdom-2.0.0-alpha.7.11.tgz#f3bbf3709e38aaa3112b5196889d0a73bd6aad95"
+"rrdom@npm:@fullview/rrdom@2.0.0-alpha.7.15":
+  version "2.0.0-alpha.7.15"
+  resolved "https://registry.yarnpkg.com/@fullview/rrdom/-/rrdom-2.0.0-alpha.7.15.tgz#f3bbf3709e38aaa3112b5196889d0a73bd6aad95"
   integrity sha512-kUXlJjbiuXZQCUPOy+Ze4zKQH9mAixM64lSf15jUztJ2BpFioX18GAO1B3qqsCRlGfinfksBHUZ1UYk/4kL2PQ==
   dependencies:
-    rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.11"
+    rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.15"
 
 rrweb-snapshot@^2.0.0-alpha.7:
   version "2.0.0-alpha.7"
@@ -11843,9 +11843,9 @@ rrweb-snapshot@^2.0.0-alpha.7:
   resolved "https://registry.yarnpkg.com/@fullview/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.7.tgz#d438455c17980cd0e794f5793940c9e5573cdde6"
   integrity sha512-+pBtwT7QIZ8mRuBMGeCfHuy7wPT1b0kTdJ6DLJ2S1qO7pLEKwbvLYNDD9ElOupbXqGpdMoCAa6zmWRU6+brQEQ==
 
-"rrweb-snapshot@npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.11":
-  version "2.0.0-alpha.7.11"
-  resolved "https://registry.yarnpkg.com/@fullview/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.7.11.tgz#d3381ae0aac753fa9525ea8fa54076fba7473a37"
+"rrweb-snapshot@npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.15":
+  version "2.0.0-alpha.7.15"
+  resolved "https://registry.yarnpkg.com/@fullview/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.7.15.tgz#d3381ae0aac753fa9525ea8fa54076fba7473a37"
   integrity sha512-3YZw5gVJbBixFfxms6aKFTSjpC20aMCqNQ1Xj0sQ/CPLf1dlrsWLva+/HhYEnaDygv92sIIhnYJngHLtrBaJNQ==
 
 rrweb@^2.0.0-alpha.7:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2622,12 +2622,12 @@
   dependencies:
     rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7"
 
-"@rrweb/types@npm:@fullview/rrweb-types@2.0.0-alpha.7.2":
-  version "2.0.0-alpha.7.2"
-  resolved "https://registry.yarnpkg.com/@fullview/rrweb-types/-/rrweb-types-2.0.0-alpha.7.2.tgz#bf9536468dda73ceaaa2f102b5dd45cd5c23fdcc"
-  integrity sha512-T7vHTAeNjsha+UAnLY+xLiWh3ZzhEykwSepIT5E4pJ99IDhWLyhn1D0wvs+UZy+y95lLTelz3UA+hj1e+3B1Rg==
+"@rrweb/types@npm:@fullview/rrweb-types@2.0.0-alpha.7.11":
+  version "2.0.0-alpha.7.11"
+  resolved "https://registry.yarnpkg.com/@fullview/rrweb-types/-/rrweb-types-2.0.0-alpha.7.11.tgz#eb920713d2370680bd50bf02590528f675a317e7"
+  integrity sha512-8/4hNVOkppsEgd43Mtg+MbbsAIHXzV39nxMUCKmBw0aJyP2eYM4HQqz5Cq0/d8RVOrdMKW7/48ztTB3Lbdpbxg==
   dependencies:
-    rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.2"
+    rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.11"
 
 "@rushstack/node-core-library@3.53.2", "@rushstack/node-core-library@^3.53.2":
   version "3.53.2"
@@ -11826,12 +11826,12 @@ rrdom@^2.0.0-alpha.7:
   dependencies:
     rrweb-snapshot "^2.0.0-alpha.7"
 
-"rrdom@npm:@fullview/rrdom@2.0.0-alpha.7.2":
-  version "2.0.0-alpha.7.2"
-  resolved "https://registry.yarnpkg.com/@fullview/rrdom/-/rrdom-2.0.0-alpha.7.2.tgz#cf9781f5145ec805fbcecacbf3814058dccdb986"
-  integrity sha512-o162OJg3uy47CqeVGLbRNL07JshhpVdP/o01ZRHE0lHGFLWhAs0QZ5NwlEfqJ2mP2pthrQILc5aq0g72CKZusw==
+"rrdom@npm:@fullview/rrdom@2.0.0-alpha.7.11":
+  version "2.0.0-alpha.7.11"
+  resolved "https://registry.yarnpkg.com/@fullview/rrdom/-/rrdom-2.0.0-alpha.7.11.tgz#f3bbf3709e38aaa3112b5196889d0a73bd6aad95"
+  integrity sha512-kUXlJjbiuXZQCUPOy+Ze4zKQH9mAixM64lSf15jUztJ2BpFioX18GAO1B3qqsCRlGfinfksBHUZ1UYk/4kL2PQ==
   dependencies:
-    rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.2"
+    rrweb-snapshot "npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.11"
 
 rrweb-snapshot@^2.0.0-alpha.7:
   version "2.0.0-alpha.7"
@@ -11843,10 +11843,10 @@ rrweb-snapshot@^2.0.0-alpha.7:
   resolved "https://registry.yarnpkg.com/@fullview/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.7.tgz#d438455c17980cd0e794f5793940c9e5573cdde6"
   integrity sha512-+pBtwT7QIZ8mRuBMGeCfHuy7wPT1b0kTdJ6DLJ2S1qO7pLEKwbvLYNDD9ElOupbXqGpdMoCAa6zmWRU6+brQEQ==
 
-"rrweb-snapshot@npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.2":
-  version "2.0.0-alpha.7.2"
-  resolved "https://registry.yarnpkg.com/@fullview/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.7.2.tgz#7b655ab8b5d90694a7829f7cf091f51914fca4a5"
-  integrity sha512-Shxl+BmWRKtKz38dErwqGlwHpRoezG106O5aoUTrNBT8ruhysNxft2ySer76j5wHO3v3FsufeMtI61+fEValig==
+"rrweb-snapshot@npm:@fullview/rrweb-snapshot@2.0.0-alpha.7.11":
+  version "2.0.0-alpha.7.11"
+  resolved "https://registry.yarnpkg.com/@fullview/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.7.11.tgz#d3381ae0aac753fa9525ea8fa54076fba7473a37"
+  integrity sha512-3YZw5gVJbBixFfxms6aKFTSjpC20aMCqNQ1Xj0sQ/CPLf1dlrsWLva+/HhYEnaDygv92sIIhnYJngHLtrBaJNQ==
 
 rrweb@^2.0.0-alpha.7:
   version "2.0.0-alpha.7"


### PR DESCRIPTION
Enhance maskInputValue to take the `maskTextSelector` into account.

Before this fix, input masking ignored this selector and we had a custom solution on our SDK, but it wasn't catching all the cases where inputs were rendered by rrweb.