### PR TITLE
Add largeMutationsConfig

### DIFF
--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb",
-  "version": "2.0.0-alpha.7.61.0",
+  "version": "2.0.0-alpha.7.16",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb",
-  "version": "2.0.0-alpha.7.16",
+  "version": "2.0.0-alpha.7.22",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb",
-  "version": "2.0.0-alpha.7.15",
+  "version": "2.0.0-alpha.7.61.0",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/scripts/repl.js
+++ b/packages/rrweb/scripts/repl.js
@@ -6,6 +6,7 @@ import { EventEmitter } from 'node:events';
 import inquirer from 'inquirer';
 import puppeteer from 'puppeteer';
 import { fileURLToPath } from 'url';
+import { setTimeout } from 'timers/promises';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -32,7 +33,8 @@ void (async () => {
           const s = document.createElement('script');
           let r = false;
           s.type = 'text/javascript';
-          s.innerHTML = code;
+          s.id = 'batman';
+          s.src = 'http://127.0.0.1/rrweb.js';
           if (document.head) {
             document.head.append(s);
           } else {
@@ -43,22 +45,24 @@ void (async () => {
         }
         loadScript(rrwebCode);
 
-        win.events = [];
-        rrweb.record({
-          emit: (event) => {
-            win.events.push(event);
-            win._replLog(event);
-          },
-          plugins: [],
-          recordCanvas: true,
-          recordCrossOriginIframes: true,
-          collectFonts: true,
-        });
+        setTimeout(() => {
+          win.events = [];
+          rrweb.record({
+            emit: (event) => {
+              win.events.push(event);
+              win._replLog(event);
+            },
+            plugins: [],
+            recordCanvas: true,
+            recordCrossOriginIframes: true,
+            collectFonts: true,
+          });
+        }, 1000);
       })();
     }, code);
   }
 
-  await start('https://react-redux.realworld.io');
+  await start('https://alpha-app.rexsoftware.com/notes/#page=1');
 
   const fakeGoto = async (page, url) => {
     const intercept = async (request) => {
@@ -145,6 +149,9 @@ void (async () => {
         width: 1600,
         height: 900,
       },
+      devtools: true,
+      executablePath:
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
       args: [
         '--start-maximized',
         '--ignore-certificate-errors',

--- a/packages/rrweb/scripts/repl.js
+++ b/packages/rrweb/scripts/repl.js
@@ -32,7 +32,7 @@ void (async () => {
         function loadScript() {
           const s = document.createElement('script');
           s.type = 'text/javascript';
-          s.id = 'batman';
+          s.id = 'rrweb';
           s.src = 'http://127.0.0.1:8080/rrweb.js';
           if (document.head) {
             document.head.append(s);

--- a/packages/rrweb/scripts/repl.js
+++ b/packages/rrweb/scripts/repl.js
@@ -29,12 +29,11 @@ void (async () => {
       win.__IS_RECORDING__ = true;
 
       (async () => {
-        function loadScript(code) {
+        function loadScript() {
           const s = document.createElement('script');
-          let r = false;
           s.type = 'text/javascript';
           s.id = 'batman';
-          s.src = 'http://127.0.0.1/rrweb.js';
+          s.src = 'http://127.0.0.1:8080/rrweb.js';
           if (document.head) {
             document.head.append(s);
           } else {
@@ -56,6 +55,10 @@ void (async () => {
             recordCanvas: true,
             recordCrossOriginIframes: true,
             collectFonts: true,
+            largeMutationsConfig: {
+              limit: 1000,
+              fullSnapshotCb: 1000,
+            },
           });
         }, 1000);
       })();

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -40,6 +40,17 @@ import {
   unregisterErrorHandler,
 } from './error-handler';
 
+function debounce(fn: () => void, delay: number) {
+  let timeoutID: NodeJS.Timeout | null = null;
+  return function () {
+    if (timeoutID) {
+      clearTimeout(timeoutID);
+    }
+
+    timeoutID = setTimeout(() => fn(), delay);
+  };
+}
+
 function wrapEvent(e: event): eventWithTime {
   return {
     ...e,
@@ -187,6 +198,10 @@ function record<T = eventWithTime>(
     return e as unknown as T;
   };
   wrappedEmit = (e: eventWithTime, isCheckout?: boolean) => {
+    if (!!options.largeMutationsConfig && e.type === EventType.FullSnapshot) {
+      mutationBuffers.forEach((buf) => (buf.freezeMutations = false));
+    }
+
     if (
       mutationBuffers[0]?.isFrozen() &&
       e.type !== EventType.FullSnapshot &&
@@ -237,7 +252,6 @@ function record<T = eventWithTime>(
   };
 
   const wrappedMutationEmit = (m: mutationCallbackParam) => {
-    console.log('wrappedMutationEmit', m);
     wrappedEmit(
       wrapEvent({
         type: EventType.IncrementalSnapshot,
@@ -424,6 +438,10 @@ function record<T = eventWithTime>(
       );
   };
 
+  const debounceFullSnapshot =
+    options.largeMutationsConfig &&
+    debounce(() => takeFullSnapshot(), options.largeMutationsConfig.fullSnapshotDebounce);
+
   try {
     const handlers: listenerHandler[] = [];
 
@@ -523,6 +541,10 @@ function record<T = eventWithTime>(
                 },
               }),
             );
+          },
+          largeMutationsConfig: options.largeMutationsConfig && {
+            limit: options.largeMutationsConfig.limit,
+            fullSnapshotCb: debounceFullSnapshot,
           },
           blockClass,
           ignoreClass,

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -237,6 +237,7 @@ function record<T = eventWithTime>(
   };
 
   const wrappedMutationEmit = (m: mutationCallbackParam) => {
+    console.log('wrappedMutationEmit', m);
     wrappedEmit(
       wrapEvent({
         type: EventType.IncrementalSnapshot,

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -128,6 +128,7 @@ const moveKey = (id: number, parentId: number) => `${id}@${parentId}`;
  * controls behaviour of a MutationObserver
  */
 export default class MutationBuffer {
+  freezeMutations = false;
   private frozen = false;
   private locked = false;
 
@@ -245,9 +246,36 @@ export default class MutationBuffer {
     this.canvasManager.reset();
   }
 
-  public processMutations = (mutations: mutationRecord[]) => {
-    mutations.forEach(this.processMutation); // adds mutations to the buffer
-    this.emit(); // clears buffer if not locked/frozen
+  public processMutations = (
+    mutations: mutationRecord[],
+    largeMutationsConfig?: {
+      limit: number;
+      fullSnapshotCb?: (() => void) | undefined;
+    },
+  ) => {
+    if (this.freezeMutations) {
+      return;
+    } else if (
+      largeMutationsConfig &&
+      mutations.length >= largeMutationsConfig.limit
+    ) {
+      this.freezeMutations = true;
+
+      this.texts = [];
+      this.attributes = [];
+      this.removes = [];
+      this.addedSet = new Set<Node>();
+      this.movedSet = new Set<Node>();
+      this.droppedSet = new Set<Node>();
+      this.movedMap = {};
+
+      largeMutationsConfig.fullSnapshotCb?.();
+
+      return;
+    } else {
+      mutations.forEach(this.processMutation); // adds mutations to the buffer
+      this.emit(); // clears buffer if not locked/frozen
+    }
   };
 
   public emit = () => {

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -1243,7 +1243,6 @@ export function initObservers(
 
   return callbackWrapper(() => {
     mutationBuffers.forEach((b) => b.reset());
-    console.log('mutationObserver.disconnect()');
     mutationObserver.disconnect();
     mousemoveHandler();
     mouseInteractionHandler();

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -112,6 +112,7 @@ export function initMutationObserver(
   ) => MutationObserver)(
     callbackWrapper(mutationBuffer.processMutations.bind(mutationBuffer)),
   );
+  console.log('gg.observe()');
   observer.observe(rootEl, {
     attributes: true,
     attributeOldValue: true,
@@ -1243,6 +1244,7 @@ export function initObservers(
 
   return callbackWrapper(() => {
     mutationBuffers.forEach((b) => b.reset());
+    console.log('mutationObserver.disconnect()');
     mutationObserver.disconnect();
     mousemoveHandler();
     mouseInteractionHandler();

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -110,9 +110,8 @@ export function initMutationObserver(
   const observer = new (mutationObserverCtor as new (
     callback: MutationCallback,
   ) => MutationObserver)(
-    callbackWrapper(mutationBuffer.processMutations.bind(mutationBuffer)),
+    callbackWrapper((e) => mutationBuffer.processMutations(e, options.largeMutationsConfig)),
   );
-  console.log('gg.observe()');
   observer.observe(rootEl, {
     attributes: true,
     attributeOldValue: true,

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -71,6 +71,10 @@ export type recordOptions<T> = {
   mousemoveWait?: number;
   keepIframeSrcFn?: KeepIframeSrcFn;
   errorHandler?: ErrorHandler;
+  largeMutationsConfig?: {
+    limit: number;
+    fullSnapshotDebounce: number;
+  };
 };
 
 export type observerParam = {
@@ -82,6 +86,10 @@ export type observerParam = {
   inputCb: inputCallback;
   mediaInteractionCb: mediaInteractionCallback;
   selectionCb: selectionCallback;
+  largeMutationsConfig?: {
+    limit: number;
+    fullSnapshotCb?: () => void;
+  };
   blockClass: blockClass;
   blockSelector: string | null;
   deleteSelector: string | null;
@@ -147,6 +155,7 @@ export type MutationBufferParam = Pick<
   | 'shadowDomManager'
   | 'canvasManager'
   | 'processedNodeManager'
+  | 'largeMutationsConfig'
 >;
 
 export type ReplayPlugin = {


### PR DESCRIPTION
Added an extra record config called `largeMutations`. This allows us to prevent large mutations from being processed, and in their place, we emit a new FS. This emission is denounced. The large mutation limit and the debounce rate is configurable.

