### PR TITLE
Prevent snapshot duplications in iframes

### DIFF
--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb",
-  "version": "2.0.0-alpha.7.22",
+  "version": "2.0.0-alpha.7.23",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb",
-  "version": "2.0.0-alpha.7.23",
+  "version": "2.0.0-alpha.7.24",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -8,7 +8,6 @@ import type { StylesheetManager } from './stylesheet-manager';
 
 export class IframeManager {
   private iframes: WeakMap<HTMLIFrameElement, true> = new WeakMap();
-  private attachedIframes: WeakSet<HTMLIFrameElement> = new WeakSet();
   private crossOriginIframeMap: WeakMap<MessageEventSource, HTMLIFrameElement> =
     new WeakMap();
   public crossOriginIframeMirror = new CrossOriginIframeMirror(genId);

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -8,7 +8,7 @@ import type { StylesheetManager } from './stylesheet-manager';
 
 export class IframeManager {
   private iframes: WeakMap<HTMLIFrameElement, true> = new WeakMap();
-  private attachedIframes: WeakMap<HTMLIFrameElement, true> = new WeakMap();
+  private attachedIframes: WeakSet<HTMLIFrameElement> = new WeakSet();
   private crossOriginIframeMap: WeakMap<MessageEventSource, HTMLIFrameElement> =
     new WeakMap();
   public crossOriginIframeMirror = new CrossOriginIframeMirror(genId);
@@ -45,9 +45,7 @@ export class IframeManager {
   }
 
   public addIframe(iframeEl: HTMLIFrameElement) {
-    if (this.iframes.has(iframeEl)) return;
     this.iframes.set(iframeEl, true);
-
     if (iframeEl.contentWindow)
       this.crossOriginIframeMap.set(iframeEl.contentWindow, iframeEl);
   }
@@ -61,7 +59,7 @@ export class IframeManager {
     childSn: serializedNodeWithId,
   ) {
     if (this.attachedIframes.has(iframeEl)) return;
-    this.attachedIframes.set(iframeEl, true);
+    this.attachedIframes.add(iframeEl);
 
     this.mutationCb({
       adds: [

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -58,9 +58,6 @@ export class IframeManager {
     iframeEl: HTMLIFrameElement,
     childSn: serializedNodeWithId,
   ) {
-    if (this.attachedIframes.has(iframeEl)) return;
-    this.attachedIframes.add(iframeEl);
-
     this.mutationCb({
       adds: [
         {

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -8,6 +8,7 @@ import type { StylesheetManager } from './stylesheet-manager';
 
 export class IframeManager {
   private iframes: WeakMap<HTMLIFrameElement, true> = new WeakMap();
+  private attachedIframes: WeakMap<HTMLIFrameElement, true> = new WeakMap();
   private crossOriginIframeMap: WeakMap<MessageEventSource, HTMLIFrameElement> =
     new WeakMap();
   public crossOriginIframeMirror = new CrossOriginIframeMirror(genId);
@@ -44,7 +45,9 @@ export class IframeManager {
   }
 
   public addIframe(iframeEl: HTMLIFrameElement) {
+    if (this.iframes.has(iframeEl)) return;
     this.iframes.set(iframeEl, true);
+
     if (iframeEl.contentWindow)
       this.crossOriginIframeMap.set(iframeEl.contentWindow, iframeEl);
   }
@@ -57,6 +60,9 @@ export class IframeManager {
     iframeEl: HTMLIFrameElement,
     childSn: serializedNodeWithId,
   ) {
+    if (this.attachedIframes.has(iframeEl)) return;
+    this.attachedIframes.set(iframeEl, true);
+
     this.mutationCb({
       adds: [
         {

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -440,7 +440,10 @@ function record<T = eventWithTime>(
 
   const debounceFullSnapshot =
     options.largeMutationsConfig &&
-    debounce(() => takeFullSnapshot(), options.largeMutationsConfig.fullSnapshotDebounce);
+    debounce(
+      () => takeFullSnapshot(),
+      options.largeMutationsConfig.fullSnapshotDebounce,
+    );
 
   try {
     const handlers: listenerHandler[] = [];

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -600,7 +600,7 @@ function record<T = eventWithTime>(
         hooks,
       );
 
-      observerHandlers.set(doc, observerHandler);
+      if (preventStackedObservers) observerHandlers.set(doc, observerHandler);
 
       return observerHandler;
     };

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -445,15 +445,15 @@ function record<T = eventWithTime>(
       options.largeMutationsConfig.fullSnapshotDebounce,
     );
 
-  const observers = new WeakMap<Document, listenerHandler>();
+  const observerHandlers = new WeakMap<Document, listenerHandler>();
 
   try {
     const handlers: listenerHandler[] = [];
 
     const observe = (doc: Document, preventStackedObservers?: boolean) => {
-      if (preventStackedObservers) observers.get(doc)?.();
+      if (preventStackedObservers) observerHandlers.get(doc)?.();
 
-      const initiatedObserver = initObservers(
+      const observerHandler = initObservers(
         {
           mutationCb: wrappedMutationEmit,
           mousemoveCb: (positions, source) =>
@@ -600,9 +600,9 @@ function record<T = eventWithTime>(
         hooks,
       );
 
-      observers.set(doc, initiatedObserver);
+      observerHandlers.set(doc, observerHandler);
 
-      return initiatedObserver;
+      return observerHandler;
     };
 
     iframeManager.addLoadListener((iframeEl) => {

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -110,7 +110,9 @@ export function initMutationObserver(
   const observer = new (mutationObserverCtor as new (
     callback: MutationCallback,
   ) => MutationObserver)(
-    callbackWrapper((e) => mutationBuffer.processMutations(e, options.largeMutationsConfig)),
+    callbackWrapper((e) =>
+      mutationBuffer.processMutations(e, options.largeMutationsConfig),
+    ),
   );
   observer.observe(rootEl, {
     attributes: true,
@@ -840,7 +842,6 @@ export function initAdoptedStyleSheetObserver(
     patchTarget.prototype,
     'adoptedStyleSheets',
   );
-  
   if (!originalPropertyDescriptor)
     return () => {
       //


### PR DESCRIPTION
Whenever a `FullSnapshot` happens, rrweb processes all the iframes it finds again. This produces an undesired effect where mutations from iframes are generated multiple times at the same moment.

By adding the new conditions from this PR, this should be avoided.