### PR TITLE
Prevent iframes from stacking on Full Snapshots

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -381,6 +381,18 @@ export function needMaskingText(
   return false;
 }
 
+const iframesWithLoadListeners: WeakSet<HTMLIFrameElement> = new WeakSet();
+
+function addIframeLoadListener(
+  iframeEl: HTMLIFrameElement,
+  listener: () => unknown,
+) {
+  if (!iframesWithLoadListeners.has(iframeEl)) {
+    iframesWithLoadListeners.add(iframeEl);
+    iframeEl.addEventListener('load', listener);
+  }
+}
+
 // https://stackoverflow.com/a/36155560
 function onceIframeLoaded(
   iframeEl: HTMLIFrameElement,
@@ -407,7 +419,7 @@ function onceIframeLoaded(
         fired = true;
       }
     }, iframeLoadTimeout);
-    iframeEl.addEventListener('load', () => {
+    addIframeLoadListener(iframeEl, () => {
       clearTimeout(timer);
       fired = true;
       listener();
@@ -425,10 +437,10 @@ function onceIframeLoaded(
     // till _after_ the mutation that found this iframe has had time to process
     setTimeout(listener, 0);
 
-    return iframeEl.addEventListener('load', listener); // keep listing for future loads
+    return addIframeLoadListener(iframeEl, listener); // keep listing for future loads
   }
   // use default listener
-  iframeEl.addEventListener('load', listener);
+  addIframeLoadListener(iframeEl, listener);
 }
 
 function onceStylesheetLoaded(

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb",
-  "version": "2.0.0-alpha.16",
+  "version": "2.0.0-alpha.18",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/scripts/inject.js
+++ b/packages/rrweb/scripts/inject.js
@@ -1,0 +1,19 @@
+// this can be injected into a page to test rrweb easily
+
+const s = document.createElement('script');
+s.type = 'text/javascript';
+s.src = 'http://127.0.0.1:8080/rrweb.umd.cjs';
+document.head.append(s);
+
+setTimeout(() => {
+  const events = [];
+  rrweb.record({
+    emit: (event) => {
+      events.push(event);
+    },
+    plugins: [],
+    recordCanvas: true,
+    recordCrossOriginIframes: true,
+    collectFonts: true,
+  });
+}, 1000);

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -457,147 +457,151 @@ function record<T = eventWithTime>(
     const handlers: listenerHandler[] = [];
 
     const observe = (doc: Document, preventStackedObservers?: boolean) => {
-      if (preventStackedObservers) observerHandlers.get(doc)?.();
+      let observerHandler: listenerHandler | undefined;
 
-      const observerHandler = initObservers(
-        {
-          mutationCb: wrappedMutationEmit,
-          mousemoveCb: (positions, source) =>
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source,
-                positions,
-              },
-            }),
-          mouseInteractionCb: (d) =>
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.MouseInteraction,
-                ...d,
-              },
-            }),
-          scrollCb: wrappedScrollEmit,
-          viewportResizeCb: (d) =>
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.ViewportResize,
-                ...d,
-              },
-            }),
-          inputCb: (v) =>
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.Input,
-                ...v,
-              },
-            }),
-          mediaInteractionCb: (p) =>
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.MediaInteraction,
-                ...p,
-              },
-            }),
-          styleSheetRuleCb: (r) =>
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.StyleSheetRule,
-                ...r,
-              },
-            }),
-          styleDeclarationCb: (r) =>
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.StyleDeclaration,
-                ...r,
-              },
-            }),
-          canvasMutationCb: wrappedCanvasMutationEmit,
-          fontCb: (p) =>
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.Font,
-                ...p,
-              },
-            }),
-          selectionCb: (p) => {
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.Selection,
-                ...p,
-              },
-            });
-          },
-          customElementCb: (c) => {
-            wrappedEmit({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.CustomElement,
-                ...c,
-              },
-            });
-          },
-          largeMutationsConfig: options.largeMutationsConfig && {
-            limit: options.largeMutationsConfig.limit,
-            fullSnapshotCb: debounceFullSnapshot,
-          },
-          blockClass,
-          ignoreClass,
-          ignoreSelector,
-          maskTextClass,
-          maskTextSelector,
-          maskInputOptions,
-          inlineStylesheet,
-          sampling,
-          recordDOM,
-          recordCanvas,
-          inlineImages,
-          userTriggeredOnInput,
-          collectFonts,
-          doc,
-          maskInputFn,
-          maskTextFn,
-          keepIframeSrcFn,
-          blockSelector,
-          deleteSelector,
-          slimDOMOptions,
-          dataURLOptions,
-          mirror,
-          iframeManager,
-          stylesheetManager,
-          shadowDomManager,
-          processedNodeManager,
-          canvasManager,
-          ignoreCSSAttributes,
-          plugins:
-            plugins
-              ?.filter((p) => p.observer)
-              ?.map((p) => ({
-                observer: p.observer!,
-                options: p.options,
-                callback: (payload: object) =>
-                  wrappedEmit({
-                    type: EventType.Plugin,
-                    data: {
-                      plugin: p.name,
-                      payload,
-                    },
-                  }),
-              })) || [],
-        },
-        hooks,
-      );
+      if (preventStackedObservers) observerHandler = observerHandlers.get(doc);
 
-      if (preventStackedObservers) observerHandlers.set(doc, observerHandler);
+      if (!observerHandler) {
+        observerHandler = initObservers(
+          {
+            mutationCb: wrappedMutationEmit,
+            mousemoveCb: (positions, source) =>
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source,
+                  positions,
+                },
+              }),
+            mouseInteractionCb: (d) =>
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.MouseInteraction,
+                  ...d,
+                },
+              }),
+            scrollCb: wrappedScrollEmit,
+            viewportResizeCb: (d) =>
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.ViewportResize,
+                  ...d,
+                },
+              }),
+            inputCb: (v) =>
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.Input,
+                  ...v,
+                },
+              }),
+            mediaInteractionCb: (p) =>
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.MediaInteraction,
+                  ...p,
+                },
+              }),
+            styleSheetRuleCb: (r) =>
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.StyleSheetRule,
+                  ...r,
+                },
+              }),
+            styleDeclarationCb: (r) =>
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.StyleDeclaration,
+                  ...r,
+                },
+              }),
+            canvasMutationCb: wrappedCanvasMutationEmit,
+            fontCb: (p) =>
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.Font,
+                  ...p,
+                },
+              }),
+            selectionCb: (p) => {
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.Selection,
+                  ...p,
+                },
+              });
+            },
+            customElementCb: (c) => {
+              wrappedEmit({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.CustomElement,
+                  ...c,
+                },
+              });
+            },
+            largeMutationsConfig: options.largeMutationsConfig && {
+              limit: options.largeMutationsConfig.limit,
+              fullSnapshotCb: debounceFullSnapshot,
+            },
+            blockClass,
+            ignoreClass,
+            ignoreSelector,
+            maskTextClass,
+            maskTextSelector,
+            maskInputOptions,
+            inlineStylesheet,
+            sampling,
+            recordDOM,
+            recordCanvas,
+            inlineImages,
+            userTriggeredOnInput,
+            collectFonts,
+            doc,
+            maskInputFn,
+            maskTextFn,
+            keepIframeSrcFn,
+            blockSelector,
+            deleteSelector,
+            slimDOMOptions,
+            dataURLOptions,
+            mirror,
+            iframeManager,
+            stylesheetManager,
+            shadowDomManager,
+            processedNodeManager,
+            canvasManager,
+            ignoreCSSAttributes,
+            plugins:
+              plugins
+                ?.filter((p) => p.observer)
+                ?.map((p) => ({
+                  observer: p.observer!,
+                  options: p.options,
+                  callback: (payload: object) =>
+                    wrappedEmit({
+                      type: EventType.Plugin,
+                      data: {
+                        plugin: p.name,
+                        payload,
+                      },
+                    }),
+                })) || [],
+          },
+          hooks,
+        );
+
+        if (preventStackedObservers) observerHandlers.set(doc, observerHandler);
+      }
 
       return callbackWrapper(observerHandler);
     };


### PR DESCRIPTION
`FullSnapshots` that we request from our SDK, trigger multiple actions that affect iframes:
1. A `MutationObserver` observer is attached to each iframe found in the body. The `iframeManager` had no logic to clean up these observers when a new one was created. We had a partially working solution, but now I tightened it. Check `packages/rrweb/src/record/index.ts`.
2. When the body is serialized, if there are iframes that are found in it, they get serialized as well, but only once the `iframe` is `loaded`. This `load` event was getting attached to the iframes on each `FullSnapshot`, without a prior clean-up for the existing listeners. I wrapped the attachment in `packages/rrweb-snapshot/src/snapshot.ts` to prevent this.
