### PR TITLE
Allow Scripts

### DIFF
--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullview/rrweb",
-  "version": "2.0.0-alpha.18",
+  "version": "2.0.0-alpha.19",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -613,10 +613,7 @@ export class Replayer {
     }
 
     this.iframe = document.createElement('iframe');
-    const attributes = ['allow-same-origin'];
-    if (this.config.UNSAFE_replayCanvas) {
-      attributes.push('allow-scripts');
-    }
+    const attributes = ['allow-same-origin allow-scripts'];
     // hide iframe before first meta event
     this.iframe.style.display = 'none';
     this.iframe.setAttribute('sandbox', attributes.join(' '));


### PR DESCRIPTION
Always add `allow-scripts` option for the iframe in the player. This helps us since we rely on the ability to interact with the iframe content from the agent side.

Without `allow-scripts` Safari blocks us from attaching custom events in the iframe from the agent side. Other browsers will probably follow this approach.